### PR TITLE
Update new div class + various fixes to parsing the response

### DIFF
--- a/Wox.Plugin.GoogleSearch/GoogleSearch.cs
+++ b/Wox.Plugin.GoogleSearch/GoogleSearch.cs
@@ -45,8 +45,12 @@ namespace Wox.Plugin.GoogleSearch
             
             foreach (var e in allElementsWithClassR)
             {
-                var link = e.QuerySelector("a").Attributes.First(a => a.Name == "href").Value;
-                var title = e.QuerySelector("h3").InnerText;
+                var link = e.QuerySelector("a").Attributes.FirstOrDefault(a => a.Name == "href")?.Value;
+                var title = e.QuerySelector("h3")?.InnerText;
+
+                if (link == null || title == null)
+                    continue;
+
                 Console.WriteLine("Title: " + title);
                 Console.WriteLine("Link: " + link);
 

--- a/Wox.Plugin.GoogleSearch/GoogleSearch.cs
+++ b/Wox.Plugin.GoogleSearch/GoogleSearch.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -50,6 +50,8 @@ namespace Wox.Plugin.GoogleSearch
 
                 if (link == null || title == null)
                     continue;
+
+                title = title.Replace("&amp;", "&");
 
                 Console.WriteLine("Title: " + title);
                 Console.WriteLine("Link: " + link);

--- a/Wox.Plugin.GoogleSearch/GoogleSearch.cs
+++ b/Wox.Plugin.GoogleSearch/GoogleSearch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -40,7 +40,7 @@ namespace Wox.Plugin.GoogleSearch
             
             htmlDoc.LoadHtml(response.Content.ReadAsStringAsync().Result);
 
-            var allElementsWithClassR = htmlDoc.QuerySelectorAll("div.r");
+            var allElementsWithClassR = htmlDoc.QuerySelectorAll("div.g");
 
             
             foreach (var e in allElementsWithClassR)

--- a/Wox.Plugin.GoogleSearch/GoogleSearch.cs
+++ b/Wox.Plugin.GoogleSearch/GoogleSearch.cs
@@ -40,10 +40,10 @@ namespace Wox.Plugin.GoogleSearch
             
             htmlDoc.LoadHtml(response.Content.ReadAsStringAsync().Result);
 
-            var allElementsWithClassR = htmlDoc.QuerySelectorAll("div.g");
+            var allElementsWithClassG = htmlDoc.QuerySelectorAll("div.g");
 
             
-            foreach (var e in allElementsWithClassR)
+            foreach (var e in allElementsWithClassG)
             {
                 var link = e.QuerySelector("a").Attributes.FirstOrDefault(a => a.Name == "href")?.Value;
                 var title = e.QuerySelector("h3")?.InnerText;

--- a/Wox.Plugin.GoogleSearch/plugin.json
+++ b/Wox.Plugin.GoogleSearch/plugin.json
@@ -4,7 +4,7 @@
   "Name":"Google Search Plus",
   "Description":"Wox plugin for searching Google and navigating directly to the search results.",
   "Author":"mikemorain",
-  "Version":"1.0.0",
+  "Version":"1.0.1",
   "Language":"csharp",
   "Website":"http://www.getwox.com",
   "IcoPath": "images\\icon.png",


### PR DESCRIPTION
Google no longer uses div class r as a place holder for each of its results

Solution:
- Change the div class r to g

Additionally
- Ignore when title or link is null
- Replace ampersand character reference in title to actual symbol