### PR TITLE
Fix plugin not working

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 7.0.x
 
       - name: Build
         run: |

--- a/GoogleSearch.cs
+++ b/GoogleSearch.cs
@@ -11,8 +11,7 @@ namespace Wox.Plugin.GoogleSearch
     public class GoogleSearch
     {
         // Inspired heavily by: https://github.com/aviaryan/alfred-google-search/blob/master/src/gsearch/googlesearch.py
-        private const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-                                         "(KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36";
+        private const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0";
 
         private readonly HttpClient _client;
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-### Temporarily removed from Plugin Store
-This plugin is no longer working, see https://github.com/jjw24/Wox.Plugin.GoogleSearch/issues/5. Due to other priorities I can not guarantee a time to investigate and fix this plugin.
-
-Please feel free to jump in and help.
-
----
-
 This is a port of the Wox plugin [GoogleSearch](https://github.com/mikemorain/Wox.Plugin.GoogleSearch)(Google Search Plus) created by Mike Morain (@mikemorain).
 
 This port is intended to be used for [Flow Launcher](https://github.com/Flow-Launcher/Flow.Launcher). It will not work for Wox.
@@ -13,5 +6,5 @@ To download this plugin, go to the latest [release](https://github.com/jjw24/Wox
 
 Changes contained in this port:
 
-- Upgraded to .Net 5
+- Upgraded to .Net 7
 - Changed Wox's plugin library to Flow's plugin library

--- a/Wox.Plugin.GoogleSearch.csproj
+++ b/Wox.Plugin.GoogleSearch.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="2.1.1" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="4.4.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="HtmlAgilityPack.CssSelectors" Version="1.0.2" />
   </ItemGroup>
 

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name":"Google Search Plus",
   "Description":"Plugin for searching Google and navigating directly to the search results.",
   "Author":"mikemorain",
-  "Version":"2.0.0",
+  "Version":"2.0.1",
   "Language":"csharp",
   "Website":"https://github.com/jjw24/Wox.Plugin.GoogleSearch",
   "IcoPath": "images\\icon.png",


### PR DESCRIPTION
It seems like the issue was caused by using an outdated user agent, to which Google was returning different markup. After updating it to a modern browser, it seems to work just fine:
![image](https://github.com/user-attachments/assets/3e0ed3bd-a417-4a1e-b9ed-5a4ca25b2a79)

I'm not sure how relevant this is, but Flow Launcher currently uses .NET 7, so I updated this plugin's version to also use .NET 7. I also updated all other dependencies. It seems to work fine (screenshot above).

If everything works, and this gets merged, I have a few more improvement ideas I could make PRs for later.

Upd: It seems that my IDE replaced line endings, causing the whole file to be displayed as different. Sorry about that. This option in diff view lets you ignore whitespace:
![image](https://github.com/user-attachments/assets/48b25619-0c84-4044-9ea7-7824b02ef053)
