### PR TITLE
Implement a few small improvements

### DIFF
--- a/GoogleSearchResult.cs
+++ b/GoogleSearchResult.cs
@@ -1,8 +1,11 @@
+using System.Web;
+
 namespace Wox.Plugin.GoogleSearch
 {
     public class GoogleSearchResult
     {
         public string Name { get; set; }
         public string Url { get; set; }
+        public string DecodedUrl => HttpUtility.UrlDecode(Url);
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name":"Google Search Plus",
   "Description":"Plugin for searching Google and navigating directly to the search results.",
   "Author":"mikemorain",
-  "Version":"2.0.1",
+  "Version":"2.0.2",
   "Language":"csharp",
   "Website":"https://github.com/jjw24/Wox.Plugin.GoogleSearch",
   "IcoPath": "images\\icon.png",


### PR DESCRIPTION
* Removed unused imports
* Simplified some code, such as remembering the plugin directory path and prepending it to result icons — there's no need for that, plugin icons can use relative paths
* Made the plugin async and added debouncing (300 ms). Also passed the cancellation token down to other functions so the network requests and parsing their results can also be cancelled if the user types something during the request.
* Title and URL are now displayed decoded. I save the decoded title directly in the `GoogleSearchResult` class because it isn't used anywhere other than for displaying the result in UI. URL is used when opening it in a browser, and the encoded URL might behave differently than decoded, so I left it as is and added a new getter in `GoogleSearchResult` class instead. This getter returns the decoded URL. Below are before and after screenshots.

Before:
![Flow Launcher_9MEt6AYysw](https://github.com/user-attachments/assets/082a24bb-714e-4ab0-b2ea-751137a213cb)

After:
![Flow Launcher_afWdSBzbv4](https://github.com/user-attachments/assets/59acf425-aa55-4980-8a37-f06ad6d50217)

